### PR TITLE
importlib-metadata<5.0 added on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,9 @@ setup(
         'python_jsonschema_objects <= 0.3.12',
         'jsonref',
         'markdown<=3.2.2',
+        # Keep importlib-metadata it low, otherwise python_jsonschema_objects
+        # build on python 3.7.12 will not work on maya 2022
+        'importlib-metadata<5.0'
     ],
     tests_require=['mock', 'pytest >= 2.3.5, < 3'],
     cmdclass={'test': PyTest, 'build_plugin': BuildPlugin},


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP- https://app.clickup.com/t/3mej2mk

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [x] MacOs.
- [x] Linux.


## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->
Keep importlib-metadata it low, otherwise python_jsonschema_objects build on python 3.7.12 will not work on maya 2022

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
        
Build in python >3.7.7 and test the framework in maya 2022. Run the following import to make sure that no errors appear:
import python_jsonschema_objects as pjo