### PR TITLE
Backlog/definition object/raise missing plugin message to warning

### DIFF
--- a/source/ftrack_connect_pipeline/host/validation.py
+++ b/source/ftrack_connect_pipeline/host/validation.py
@@ -81,6 +81,12 @@ class PluginDiscoverValidation(object):
                     schema_type,
                 ):
                     valid_definition = False
+                    self.logger.debug(
+                        'Could not validate plugins of definition: {} step: {} '
+                        'of schema type: {}'.format(
+                            definition['name'], constants.CONTEXTS, schema_type
+                        )
+                    )
             except Exception as e:
                 self.logger.error(
                     'Could not validate {} contexts steps: {}'.format(
@@ -96,6 +102,12 @@ class PluginDiscoverValidation(object):
                     schema_type,
                 ):
                     valid_definition = False
+                    self.logger.debug(
+                        'Could not validate plugins of definition: {} step: {} '
+                        'of schema type: {}'.format(
+                            definition['name'], constants.COMPONENTS, schema_type
+                        )
+                    )
             except Exception as e:
                 self.logger.error(
                     'Could not validate {} components steps: {}'.format(
@@ -111,6 +123,12 @@ class PluginDiscoverValidation(object):
                     schema_type,
                 ):
                     valid_definition = False
+                    self.logger.debug(
+                        'Could not validate plugins of definition: {} step: {} '
+                        'of schema type: {}'.format(
+                            definition['name'], constants.FINALIZERS, schema_type
+                        )
+                    )
             except Exception as e:
                 self.logger.error(
                     'Could not validate {} finalizers steps: {}'.format(
@@ -151,7 +169,7 @@ class PluginDiscoverValidation(object):
                 for plugin in stage['plugins']:
                     if not self._discover_plugin(plugin, plugin_type):
                         is_valid = False
-                        self.logger.debug(
+                        self.logger.warning(
                             'Could not discover plugin {} of type {} for stage {}'
                             ' of the step {} in {}'.format(
                                 plugin['plugin'],


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-https://app.clickup.com/t/3f8p8fw

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [x] MacOs.
- [ ] Linux.


## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->
Failed plugins on discovery time are now printed as warning.
## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            