### PR TITLE
fix docs requirement bug and add standalone documentation and resources

### DIFF
--- a/doc/resource/standalone-snippets/maya_standalone_publish_snippet.py
+++ b/doc/resource/standalone-snippets/maya_standalone_publish_snippet.py
@@ -1,0 +1,58 @@
+import os
+from ftrack_connect_pipeline import constants, event
+from ftrack_connect_pipeline_maya import host
+import ftrack_api
+
+# Set the minimum required Environment variables.
+os.environ['FTRACK_EVENT_PLUGIN_PATH'] = (
+    '<path-to-your-repo-folder>/ftrack-connect-pipeline-definition/resource/plugins:'
+    '<path-to-your-repo-folder>/ftrack-connect-pipeline-definition/resource/definitions:'
+)
+
+# Create a session and Event Manager
+session = ftrack_api.Session(auto_connect_event_hub=False)
+event_manager = event.EventManager(
+    session=session, mode=constants.LOCAL_EVENT_MODE
+)
+
+# Init Maya host
+host_class = host.MayaHost(event_manager)
+
+# Init Client
+from ftrack_connect_pipeline import client
+
+client_connection = client.Client(event_manager)
+
+# Discover hosts
+client_connection.discover_hosts()
+
+# Print discovered hosts
+# client_connection.host_connections
+
+# Setup a host
+client_connection.change_host(client_connection.host_connections[0])
+
+# Set a context id
+# You can choose to set the context id in the host or in the client,
+# booth ways will work.
+host_class.context_id = '<your-context-id>'
+# client_connection.context_id = '<your-context-id>'
+
+# Select the File Publisher definition
+definition = client_connection.host_connection.definitions[
+    'publisher'
+].get_all(name='Geometry Publisher')[0]
+
+# Assign the definition to the client
+client_connection.change_definition(definition)
+
+# Make the desired changes:
+collector_plugins = definition.get_all(
+    category='plugin', type='collector', name='Geometry Collector'
+)
+collector_plugins[0].options.collected_objects = ['pCube']
+collector_plugins[1].options.collected_objects = ['pCube']
+collector_plugins[2].options.collected_objects = ['pCube']
+
+# Execute the definition.
+client_connection.run_definition()

--- a/doc/resource/standalone-snippets/python_standalone_publish_snippet.py
+++ b/doc/resource/standalone-snippets/python_standalone_publish_snippet.py
@@ -1,0 +1,60 @@
+import os
+from ftrack_connect_pipeline import host, constants, event
+import ftrack_api
+
+# Set the minimum required Environment variables.
+os.environ['FTRACK_EVENT_PLUGIN_PATH'] = (
+    '<path-to-your-repo-folder>/ftrack-connect-pipeline-definition/resource/plugins:'
+    '<path-to-your-repo-folder>/ftrack-connect-pipeline-definition/resource/definitions:'
+)
+
+# Create a session and Event Manager
+session = ftrack_api.Session(auto_connect_event_hub=False)
+event_manager = event.EventManager(
+    session=session, mode=constants.LOCAL_EVENT_MODE
+)
+
+# Init host
+host_class = host.Host(event_manager)
+
+# Init Client
+from ftrack_connect_pipeline import client
+
+client_connection = client.Client(event_manager)
+
+# Discover hosts
+client_connection.discover_hosts()
+
+# Print discovered hosts
+# client_connection.host_connections
+
+# Setup a host
+client_connection.change_host(client_connection.host_connections[0])
+
+# Set a context id
+# You can choose to set the context id in the host or in the client,
+# booth ways will work.
+host_class.context_id = '<your-context-id>'
+# client_connection.context_id = '<your-context-id>'
+
+# Select the File Publisher definition
+definition = client_connection.host_connection.definitions[
+    'publisher'
+].get_all(name='File Publisher')[0]
+
+# Assign the definition to the client
+client_connection.change_definition(definition)
+
+# Make the desired changes:
+collector_plugins = definition.get_all(category='plugin', type='collector')
+collector_plugins[0].options.path = '<Path-to-the-file-to-publish>'
+collector_plugins[1].options.path = '<Path-to-the-file-to-publish>'
+
+# Execute the definition.
+client_connection.run_definition()
+
+# You could now make more changes and run the definition again to publish a new version.
+# collector_plugins = definition.get_all(category='plugin', type='collector')
+# collector_plugins[0].options.path='<Path-to-another-file-to-publish>'
+# collector_plugins[1].options.path='<Path-to-another-file-to-publish>'
+# client_connection.run_definition()

--- a/doc/standalone.rst
+++ b/doc/standalone.rst
@@ -37,10 +37,10 @@ All the definitions with host_type maya and python will be discovered.
 
 .. warning::
 
-    Maya has to be launched using connect otherwise the user will have to
-    manually setup all the environment variables for maya to be able to run the
-    framework. We are working on providing an easy way to launch maya by command
-    with the framework pre-loaded.
+    DCC launch is subject to be improved in future releases of the framework,
+    making it possible to share launcher with Connect to enable consistent and
+    context aware framework setup. For now we highly recommend to launch DCC from
+    connect to avoid having to manually setup all the environment variables.
 
 **mypipeline/standalone-snippets/maya_standalone_publish_snippet.py**
 

--- a/doc/standalone.rst
+++ b/doc/standalone.rst
@@ -12,5 +12,38 @@ Standalone
 This section describes how to use the pipeline Framework in standalone mode, from with
 the DCC application or outside.
 
-TBC
+***************
+Python Example
+***************
 
+This is an example on how to run the framework in a python console without
+Connect or any DCC running on the background, this way the framework is able to
+discover any definition where the host type is python.
+
+**mypipeline/standalone-snippets/python_standalone_publish_snippet.py**
+
+.. literalinclude:: /resource/standalone-snippets/python_standalone_publish_snippet.py
+    :language: python
+    :linenos:
+
+
+*****************
+DCC Maya Example
+*****************
+
+This is an example on how to run the framework inside the maya console.
+All the definitions with host_type maya and python will be discovered.
+
+
+.. warning::
+
+    Maya has to be launched using connect otherwise the user will have to
+    manually setup all the environment variables for maya to be able to run the
+    framework. We are working on providing an easy way to launch maya by command
+    with the framework pre-loaded.
+
+**mypipeline/standalone-snippets/maya_standalone_publish_snippet.py**
+
+.. literalinclude:: /resource/standalone-snippets/maya_standalone_publish_snippet.py
+    :language: python
+    :linenos:

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,7 @@ setup(
         'lowdown >= 0.1.0, < 2',
         'setuptools>=44.0.0',
         'setuptools_scm',
+        'Jinja2<3.1'
     ],
     install_requires=[
         'ftrack-python-api >= 1, < 3',  # == 2.0RC1


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-https://app.clickup.com/t/3kqrvuv

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [x] MacOs.
- [ ] Linux.


## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->
Added an example on how to use framework in standalone mode.
Fixed bug on building docs, adding Jinja2<3.1 as requirement for the setup.py.

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
Build with python setup.py build_sphinx. No errors should appear.
Please visit the following page to see the result:
https://ftrack-connect-pipeline.readthedocs.io/en/backlog-documentation-standalone-documentation/standalone.html            