### PR TITLE
feat: Backlog/fix init asset

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -9,6 +9,11 @@ Release Notes
 
 .. release:: upcoming
     .. change:: changed
+        :tags: load_asset
+
+        Init nodes returning dictionary with result key and not run_method key.
+
+    .. change:: changed
         :tags: collector
 
         Common loader and opener collector return value changed from list to dictionary

--- a/source/ftrack_connect_pipeline/plugin/load/importer.py
+++ b/source/ftrack_connect_pipeline/plugin/load/importer.py
@@ -108,6 +108,8 @@ class LoaderImporterPlugin(base.BaseImporterPlugin):
             component_name=component_name,
             component_path=component_path,
             component_id=component_id,
+            load_mode=options.get(asset_const.LOAD_MODE),
+            asset_info_options=options.get(asset_const.ASSET_INFO_OPTIONS)
         )
 
         self.asset_info = asset_info

--- a/source/ftrack_connect_pipeline/plugin/load/importer.py
+++ b/source/ftrack_connect_pipeline/plugin/load/importer.py
@@ -147,7 +147,7 @@ class LoaderImporterPlugin(base.BaseImporterPlugin):
         result = {
             'asset_info': self.asset_info,
             'dcc_object': self.dcc_object,
-            'run_method': run_result,
+            'result': run_result,
         }
 
         return result

--- a/source/ftrack_connect_pipeline/plugin/open/importer.py
+++ b/source/ftrack_connect_pipeline/plugin/open/importer.py
@@ -147,7 +147,7 @@ class OpenerImporterPlugin(base.BaseImporterPlugin):
         result = {
             'asset_info': self.asset_info,
             'dcc_object': self.dcc_object,
-            'run_method': run_result,
+            'result': run_result,
         }
 
         return result

--- a/source/ftrack_connect_pipeline/plugin/open/importer.py
+++ b/source/ftrack_connect_pipeline/plugin/open/importer.py
@@ -108,6 +108,8 @@ class OpenerImporterPlugin(base.BaseImporterPlugin):
             component_name=component_name,
             component_path=component_path,
             component_id=component_id,
+            load_mode=options.get(asset_const.LOAD_MODE),
+            asset_info_options=options.get(asset_const.ASSET_INFO_OPTIONS)
         )
 
         self.asset_info = asset_info


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-https://app.clickup.com/t/865bktgr5
  * FT-
  * SENTRY-
  * ZENDESK-

-->

Resolves <!--Task reference -->

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [x] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->
Fix the arguments passed to create the asset info in the init_node method of the loader/opener importer.
Change run_method to result in the return value key of the load_asset method of the loader/opener importer.
## Test
<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
